### PR TITLE
feat(site): add hexo feed generator

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ keywords: null
 author: Souiken
 language: zh-CN
 timezone: ''
-url: http://example.com
+url: https://blog.souiken.moe
 permalink: 'post/:title/'
 permalink_defaults: null
 pretty_urls:
@@ -123,3 +123,16 @@ markdown:
     permalinkSymbol: "¶"
     case: 0
     separator: "-"
+feed:
+  enable: true
+  type: atom
+  path: atom.xml
+  limit: 20
+  hub:
+  content:
+  content_limit: 140
+  content_limit_delim: ' '
+  order_by: -date
+  icon: icon.png
+  autodiscovery: true
+  template:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "hexo-filter-mathjax": "^0.9.0",
     "hexo-generator-archive": "^2.0.0",
     "hexo-generator-category": "^2.0.0",
+    "hexo-generator-feed": "^3.0.0",
     "hexo-generator-index": "^3.0.0",
     "hexo-generator-search": "^2.4.3",
     "hexo-generator-tag": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,6 +813,14 @@ hexo-generator-category@^2.0.0:
   dependencies:
     hexo-pagination "3.0.0"
 
+hexo-generator-feed@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hexo-generator-feed/-/hexo-generator-feed-3.0.0.tgz#4126ef5e308264c42599fb0efdaf88ed11fa599e"
+  integrity sha512-Jo35VSRSNeMitS2JmjCq3OHAXXYU4+JIODujHtubdG/NRj2++b3Tgyz9pwTmROx6Yxr2php/hC8og5AGZHh8UQ==
+  dependencies:
+    hexo-util "^2.1.0"
+    nunjucks "^3.0.0"
+
 hexo-generator-index@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hexo-generator-index/-/hexo-generator-index-3.0.0.tgz#4c9233731e027a6af6491886a4aafe08ffdaffe0"
@@ -1556,7 +1564,7 @@ normalize-url@^6.0.1:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
-nunjucks@^3.0.1, nunjucks@^3.2.3:
+nunjucks@^3.0.0, nunjucks@^3.0.1, nunjucks@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.4.tgz#f0878eef528ce7b0aa35d67cc6898635fd74649e"
   integrity sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==


### PR DESCRIPTION
This pull request introduces support for Atom feeds in the Hexo blog.

Adds [hexojs/hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) to generate Atom feed at https://blog.souiken.moe/atom.xml, which exists now in site theme but cannot be accessed (404 Not Found).

Feed support and configuration:

* Enabled Atom feed generation in `_config.yml` by adding a `feed` section with default options such as type, path, content limits, and autodiscovery.
* Added `hexo-generator-feed` to the project's dependencies in `package.json` to provide feed generation functionality.

Site configuration:

* Updated the `url` field in `_config.yml` to use the site URL `https://blog.souiken.moe`.
